### PR TITLE
Add sensible default for fetch

### DIFF
--- a/src/service/overriding.service.ts
+++ b/src/service/overriding.service.ts
@@ -30,7 +30,7 @@ export class OverridingService {
 
     if (typeof input === "string") {
       apiUrl = input;
-      apiMethod = init.method;
+      apiMethod = init?.method || 'GET';
     } else {
       apiUrl = input.url;
       apiMethod = input.method as Method;


### PR DESCRIPTION
Hey @DelphiDesigner, great addon! 🎉 

By default, `fetch(url)` will yield a GET request. 
If `init` is not passed, it should use the method GET. Currently, the code breaks in that scenario.